### PR TITLE
feat: auto-include `RCTNetworking` shared

### DIFF
--- a/apps/example-host/metro.config.js
+++ b/apps/example-host/metro.config.js
@@ -40,12 +40,6 @@ module.exports = withModuleFederation(
         requiredVersion: '0.80.0',
         version: '0.80.0',
       },
-      'react-native/Libraries/Network/RCTNetworking': {
-        singleton: true,
-        eager: true,
-        requiredVersion: '0.80.0',
-        version: '0.80.0',
-      },
       lodash: {
         singleton: false,
         eager: false,

--- a/apps/example-mini/metro.config.js
+++ b/apps/example-mini/metro.config.js
@@ -41,12 +41,6 @@ module.exports = withModuleFederation(
         version: '0.80.0',
         import: false,
       },
-      'react-native/Libraries/Network/RCTNetworking': {
-        singleton: true,
-        eager: false,
-        requiredVersion: '0.80.0',
-        version: '0.80.0',
-      },
       lodash: {
         singleton: false,
         eager: false,

--- a/apps/example-nested-mini/metro.config.js
+++ b/apps/example-nested-mini/metro.config.js
@@ -44,12 +44,6 @@ module.exports = withModuleFederation(
         version: '0.80.0',
         import: false,
       },
-      'react-native/Libraries/Network/RCTNetworking': {
-        singleton: true,
-        eager: false,
-        requiredVersion: '0.80.0',
-        version: '0.80.0',
-      },
       lodash: {
         singleton: false,
         eager: false,

--- a/apps/showcase-host/metro.config.js
+++ b/apps/showcase-host/metro.config.js
@@ -39,12 +39,6 @@ module.exports = withModuleFederation(
         requiredVersion: '0.80.0',
         version: '0.80.0',
       },
-      'react-native/Libraries/Network/RCTNetworking': {
-        singleton: true,
-        eager: true,
-        requiredVersion: '0.80.0',
-        version: '0.80.0',
-      },
       lodash: {
         singleton: false,
         eager: false,

--- a/apps/showcase-mini/metro.config.js
+++ b/apps/showcase-mini/metro.config.js
@@ -42,13 +42,6 @@ module.exports = withModuleFederation(
         version: '0.80.0',
         import: false,
       },
-      'react-native/Libraries/Network/RCTNetworking': {
-        singleton: true,
-        eager: false,
-        requiredVersion: '0.80.0',
-        version: '0.80.0',
-        import: false,
-      },
       lodash: {
         singleton: false,
         eager: false,

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -58,12 +58,13 @@ function augmentConfig(
   const isRemote = !isHost;
 
   const tmpDirPath = prepareTmpDir(config.projectRoot);
+
+  validateOptions(federationOptions);
+
   const options = normalizeOptions(federationOptions, {
     projectRoot: config.projectRoot,
     tmpDirPath,
   });
-
-  validateOptions(options);
 
   const vmManager = new VirtualModuleManager(config);
 

--- a/packages/core/src/plugin/normalize-options.ts
+++ b/packages/core/src/plugin/normalize-options.ts
@@ -54,6 +54,14 @@ function getNormalizedShared(
     }
   }
 
+  // auto-include `react-native/Libraries/Network/RCTNetworking`
+  if (!shared['react-native/Libraries/Network/RCTNetworking']) {
+    const reactNativeSharedConfig = shared['react-native'];
+    // use the same config as `react-native`
+    shared['react-native/Libraries/Network/RCTNetworking'] =
+      reactNativeSharedConfig;
+  }
+
   return shared;
 }
 

--- a/packages/core/src/plugin/validate-options.ts
+++ b/packages/core/src/plugin/validate-options.ts
@@ -1,7 +1,12 @@
-import type { ModuleFederationConfigNormalized, Shared } from '../types';
+import type { ModuleFederationConfig, Shared } from '../types';
 import { ConfigError } from '../utils';
 
-function validateFilename(filename: string) {
+function validateFilename(filename: string | undefined) {
+  // filename is optional
+  if (!filename) {
+    return;
+  }
+
   if (!filename.endsWith('.bundle')) {
     throw new ConfigError(
       `Invalid filename: ${filename}. ` +
@@ -10,13 +15,28 @@ function validateFilename(filename: string) {
   }
 }
 
-function validateShared(shared: Shared) {
-  if (!shared || typeof shared !== 'object') {
+function validateShared(shared: Shared | undefined) {
+  if (!shared) {
+    throw new ConfigError('Shared configuration is required.');
+  }
+
+  if (typeof shared !== 'object') {
     throw new ConfigError('Shared must be an object.');
   }
 
   if (Array.isArray(shared)) {
     throw new ConfigError('Array format is not supported for shared.');
+  }
+
+  // validate react & react-native present
+  if (!('react' in shared)) {
+    throw new ConfigError("Dependency 'react' must be present in shared.");
+  }
+
+  if (!('react-native' in shared)) {
+    throw new ConfigError(
+      "Dependency 'react-native' must be present in shared."
+    );
   }
 
   // validate shared module names
@@ -45,7 +65,7 @@ function validateShared(shared: Shared) {
   }
 }
 
-export function validateOptions(options: ModuleFederationConfigNormalized) {
+export function validateOptions(options: ModuleFederationConfig) {
   // validate filename
   validateFilename(options.filename);
 


### PR DESCRIPTION
### Summary

Since our `async-require` uses `RCTNetworking` we need to always have declared as a shared dependency. This PR removes a need for including it manually in shared configuration