### PR TITLE
feat: virtual host entry

### DIFF
--- a/apps/example-host/index.js
+++ b/apps/example-host/index.js
@@ -1,9 +1,3 @@
-// we need to explicitly import the init-host runtime module
-// this is because of a metro limitation, where the module
-// must be used in the bundle in order to be present in the final bundle
-import 'mf:init-host';
-import 'mf:async-require';
-
 import { withAsyncStartup } from '@module-federation/metro/bootstrap';
 import { AppRegistry } from 'react-native';
 import { name as appName } from './app.json';

--- a/apps/showcase-host/index.js
+++ b/apps/showcase-host/index.js
@@ -1,9 +1,3 @@
-// we need to explicitly import the init-host runtime module
-// this is because of a metro limitation, where the module
-// must be used in the bundle in order to be present in the final bundle
-import 'mf:init-host';
-import 'mf:async-require';
-
 import { withAsyncStartup } from '@module-federation/metro/bootstrap';
 import { AppRegistry } from 'react-native';
 import { name as appName } from './app.json';

--- a/packages/core/src/commands/bundle-host/index.ts
+++ b/packages/core/src/commands/bundle-host/index.ts
@@ -5,7 +5,7 @@ import type { RequestOptions } from 'metro/src/shared/types';
 import type { ModuleFederationConfigNormalized } from '../../types';
 import { CLIError } from '../../utils/errors';
 import type { Config } from '../types';
-import { createResolver } from '../utils/create-resolver.js';
+import { createResolver } from '../utils/create-resolver';
 import { getCommunityCliPlugin } from '../utils/get-community-plugin';
 import loadMetroConfig from '../utils/load-metro-config';
 import { saveBundleAndMap } from '../utils/save-bundle-and-map';

--- a/packages/core/src/commands/bundle-host/index.ts
+++ b/packages/core/src/commands/bundle-host/index.ts
@@ -1,16 +1,31 @@
 import Server from 'metro/src/Server';
 import type { RequestOptions } from 'metro/src/shared/types';
+import { VIRTUAL_HOST_ENTRY_NAME } from '../../plugin/constants';
+import type { ModuleFederationConfigNormalized } from '../../types';
 import type { Config } from '../types';
 import { getCommunityCliPlugin } from '../utils/get-community-plugin';
 import loadMetroConfig from '../utils/load-metro-config';
 import { saveBundleAndMap } from '../utils/save-bundle-and-map';
 import type { BundleFederatedHostArgs } from './types';
 
+declare global {
+  var __METRO_FEDERATION_CONFIG: ModuleFederationConfigNormalized;
+  var __METRO_FEDERATION_ORIGINAL_ENTRY_PATH: string | undefined;
+  var __METRO_FEDERATION_REMOTE_ENTRY_PATH: string | undefined;
+  var __METRO_FEDERATION_MANIFEST_PATH: string | undefined;
+}
+
 async function bundleFederatedHost(
   _argv: Array<string>,
   cfg: Config,
   args: BundleFederatedHostArgs
 ): Promise<void> {
+  // expose original entrypoint
+  global.__METRO_FEDERATION_ORIGINAL_ENTRY_PATH = args.entryFile;
+
+  // use virtual host entrypoint
+  args.entryFile = VIRTUAL_HOST_ENTRY_NAME;
+
   const config = await loadMetroConfig(cfg, {
     maxWorkers: args.maxWorkers,
     resetCache: args.resetCache,

--- a/packages/core/src/commands/bundle-remote/index.ts
+++ b/packages/core/src/commands/bundle-remote/index.ts
@@ -223,7 +223,7 @@ async function bundleFederatedRemote(
   // hack: resolve the container entry to register it as a virtual module
   resolver.resolve({
     from: config.projectRoot,
-    to: `./${path.basename(containerEntryFilepath)}`,
+    to: `./${path.relative(config.projectRoot, containerEntryFilepath)}`,
   });
 
   const exposedModules = Object.entries(federationConfig.exposes)

--- a/packages/core/src/commands/bundle-remote/index.ts
+++ b/packages/core/src/commands/bundle-remote/index.ts
@@ -19,6 +19,7 @@ const DEFAULT_OUTPUT = 'dist';
 
 declare global {
   var __METRO_FEDERATION_CONFIG: ModuleFederationConfigNormalized;
+  var __METRO_FEDERATION_ORIGINAL_ENTRY_PATH: string | undefined;
   var __METRO_FEDERATION_REMOTE_ENTRY_PATH: string | undefined;
   var __METRO_FEDERATION_MANIFEST_PATH: string | undefined;
 }

--- a/packages/core/src/plugin/constants.ts
+++ b/packages/core/src/plugin/constants.ts
@@ -4,6 +4,10 @@ export const ASYNC_REQUIRE = 'mf:async-require';
 export const REMOTE_MODULE_REGISTRY = 'mf:remote-module-registry';
 export const REMOTE_HMR_SETUP = 'mf:remote-hmr';
 
+// virtual entrypoint names
+export const VIRTUAL_HOST_ENTRY_NAME = 'virtual-host-entry';
+export const VIRTUAL_REMOTE_ENTRY_NAME = 'virtual-remote-entry';
+
 // defaults
 export const DEFAULT_ENTRY_FILENAME = 'remoteEntry.bundle';
 

--- a/packages/core/src/plugin/constants.ts
+++ b/packages/core/src/plugin/constants.ts
@@ -4,10 +4,6 @@ export const ASYNC_REQUIRE = 'mf:async-require';
 export const REMOTE_MODULE_REGISTRY = 'mf:remote-module-registry';
 export const REMOTE_HMR_SETUP = 'mf:remote-hmr';
 
-// virtual entrypoint names
-export const VIRTUAL_HOST_ENTRY_NAME = 'virtual-host-entry';
-export const VIRTUAL_REMOTE_ENTRY_NAME = 'virtual-remote-entry';
-
 // defaults
 export const DEFAULT_ENTRY_FILENAME = 'remoteEntry.bundle';
 

--- a/packages/core/src/plugin/generators.ts
+++ b/packages/core/src/plugin/generators.ts
@@ -7,6 +7,18 @@ export function getRemoteModule(name: string) {
   return template.replaceAll('__MODULE_ID__', `"${name}"`);
 }
 
+export function getHostEntryModule(
+  _: ModuleFederationConfigNormalized,
+  paths: { tmpDir: string; projectDir: string }
+) {
+  const indexPath = path.join(paths.projectDir, 'index.js');
+  const template = getModuleTemplate('host-entry.js');
+  return template.replaceAll(
+    '__ENTRYPOINT_IMPORT__',
+    `import './${path.relative(paths.tmpDir, indexPath)}'`
+  );
+}
+
 export function getInitHostModule(options: ModuleFederationConfigNormalized) {
   const template = getModuleTemplate('init-host.js');
   return template

--- a/packages/core/src/plugin/generators.ts
+++ b/packages/core/src/plugin/generators.ts
@@ -9,13 +9,12 @@ export function getRemoteModule(name: string) {
 
 export function getHostEntryModule(
   _: ModuleFederationConfigNormalized,
-  paths: { tmpDir: string; projectDir: string }
+  paths: { originalEntry: string; tmpDir: string }
 ) {
-  const indexPath = path.join(paths.projectDir, 'index.js');
   const template = getModuleTemplate('host-entry.js');
   return template.replaceAll(
     '__ENTRYPOINT_IMPORT__',
-    `import './${path.relative(paths.tmpDir, indexPath)}'`
+    `import './${path.relative(paths.tmpDir, paths.originalEntry)}'`
   );
 }
 

--- a/packages/core/src/plugin/helpers.ts
+++ b/packages/core/src/plugin/helpers.ts
@@ -17,6 +17,10 @@ export function replaceExtension(filepath: string, extension: string) {
   return path.format({ dir, name, ext: extension });
 }
 
+export function removeExtension(filepath: string) {
+  return replaceExtension(filepath, '');
+}
+
 export function stubHostEntry(hostEntryPath: string) {
   const stub = '// host entry stub';
   fs.mkdirSync(path.dirname(hostEntryPath), { recursive: true });

--- a/packages/core/src/plugin/helpers.ts
+++ b/packages/core/src/plugin/helpers.ts
@@ -17,6 +17,12 @@ export function replaceExtension(filepath: string, extension: string) {
   return path.format({ dir, name, ext: extension });
 }
 
+export function stubHostEntry(hostEntryPath: string) {
+  const stub = '// host entry stub';
+  fs.mkdirSync(path.dirname(hostEntryPath), { recursive: true });
+  fs.writeFileSync(hostEntryPath, stub, 'utf-8');
+}
+
 export function stubRemoteEntry(remoteEntryPath: string) {
   const stub = '// remote entry stub';
   fs.mkdirSync(path.dirname(remoteEntryPath), { recursive: true });

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -11,6 +11,7 @@ import {
   isUsingMFCommand,
   prepareTmpDir,
   replaceExtension,
+  stubHostEntry,
   stubRemoteEntry,
 } from './helpers';
 import { createManifest } from './manifest';
@@ -67,6 +68,7 @@ function augmentConfig(
 
   const vmManager = new VirtualModuleManager(config);
 
+  const hostEntryPath = path.resolve(tmpDirPath, 'hostEntry.js');
   const initHostPath = path.resolve(tmpDirPath, 'init-host.js');
 
   const remoteEntryFilename = replaceExtension(options.filename, '.js');
@@ -88,8 +90,9 @@ function augmentConfig(
 
   const manifestPath = createManifest(options, tmpDirPath);
 
-  // remote entry is an entrypoint so it needs to be in the filesystem
-  // we create a stub on the filesystem and then redirect to a virtual module
+  // host & remote entry is are entrypoints so they needs to be present in the filesystem
+  // we create stubs on the filesystem and then redirect corresponding virtual modules
+  stubHostEntry(hostEntryPath);
   stubRemoteEntry(remoteEntryPath);
 
   // pass data to bundle-mf-remote command

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -128,8 +128,9 @@ function augmentConfig(
         vmManager,
         options,
         paths: {
-          initHost: initHostPath,
           asyncRequire: asyncRequirePath,
+          hostEntry: hostEntryPath,
+          initHost: initHostPath,
           remoteModuleRegistry: remoteModuleRegistryPath,
           remoteHMRSetup: remoteHMRSetupPath,
           remoteEntry: remoteEntryPath,

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -23,6 +23,7 @@ import { validateOptions } from './validate-options';
 
 declare global {
   var __METRO_FEDERATION_CONFIG: ModuleFederationConfigNormalized;
+  var __METRO_FEDERATION_ORIGINAL_ENTRY_PATH: string | undefined;
   var __METRO_FEDERATION_REMOTE_ENTRY_PATH: string | undefined;
   var __METRO_FEDERATION_MANIFEST_PATH: string | undefined;
 }
@@ -69,10 +70,9 @@ function augmentConfig(
   const vmManager = new VirtualModuleManager(config);
 
   // original host entrypoint, usually <projectRoot>/index.js
-  const originalEntryFilename = 'index.js';
-  const originalEntryPath = path.resolve(
+  const { originalEntryFilename, originalEntryPath } = getOriginalEntry(
     config.projectRoot,
-    originalEntryFilename
+    'index.js'
   );
 
   // virtual host entrypoint
@@ -163,4 +163,21 @@ function augmentConfig(
       }),
     },
   };
+}
+
+function getOriginalEntry(
+  projectRoot: string,
+  entryFilename: string
+): {
+  originalEntryFilename: string;
+  originalEntryPath: string;
+} {
+  const originalEntryFilename = path.basename(
+    global.__METRO_FEDERATION_ORIGINAL_ENTRY_PATH ?? entryFilename
+  );
+  const originalEntryPath = path.resolve(
+    projectRoot,
+    global.__METRO_FEDERATION_ORIGINAL_ENTRY_PATH ?? entryFilename
+  );
+  return { originalEntryFilename, originalEntryPath };
 }

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -109,6 +109,7 @@ function augmentConfig(
 
   // pass data to bundle-mf-remote command
   global.__METRO_FEDERATION_CONFIG = options;
+  global.__METRO_FEDERATION_HOST_ENTRY_PATH = hostEntryPath;
   global.__METRO_FEDERATION_REMOTE_ENTRY_PATH = remoteEntryPath;
   global.__METRO_FEDERATION_MANIFEST_PATH = manifestPath;
 

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -144,6 +144,7 @@ function augmentConfig(
       rewriteRequestUrl: createRewriteRequest({
         options,
         config,
+        hostEntryPath,
         manifestPath,
       }),
     },

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -68,11 +68,23 @@ function augmentConfig(
 
   const vmManager = new VirtualModuleManager(config);
 
-  const hostEntryPath = path.resolve(tmpDirPath, 'hostEntry.js');
-  const initHostPath = path.resolve(tmpDirPath, 'init-host.js');
+  // original host entrypoint, usually <projectRoot>/index.js
+  const originalEntryFilename = 'index.js';
+  const originalEntryPath = path.resolve(
+    config.projectRoot,
+    originalEntryFilename
+  );
 
+  // virtual host entrypoint
+  const hostEntryFilename = originalEntryFilename;
+  const hostEntryPath = path.resolve(tmpDirPath, hostEntryFilename);
+
+  // virtual remote entrypoint
   const remoteEntryFilename = replaceExtension(options.filename, '.js');
   const remoteEntryPath = path.resolve(tmpDirPath, remoteEntryFilename);
+
+  // other virtual modules
+  const initHostPath = path.resolve(tmpDirPath, 'init-host.js');
   const remoteHMRSetupPath = path.resolve(tmpDirPath, 'remote-hmr.js');
   const remoteModuleRegistryPath = path.resolve(
     tmpDirPath,
@@ -129,6 +141,7 @@ function augmentConfig(
         options,
         paths: {
           asyncRequire: asyncRequirePath,
+          originalEntry: originalEntryPath,
           hostEntry: hostEntryPath,
           initHost: initHostPath,
           remoteModuleRegistry: remoteModuleRegistryPath,
@@ -143,9 +156,9 @@ function augmentConfig(
       ...config.server,
       enhanceMiddleware: vmManager.getMiddleware(),
       rewriteRequestUrl: createRewriteRequest({
-        options,
         config,
-        hostEntryPath,
+        originalEntryFilename,
+        remoteEntryFilename,
         manifestPath,
       }),
     },

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -103,7 +103,7 @@ function augmentConfig(
 
   const manifestPath = createManifest(options, tmpDirPath);
 
-  // host & remote entry is are entrypoints so they needs to be present in the filesystem
+  // host and remote entries are entry points, so they need to be present in the filesystem
   // we create stubs on the filesystem and then redirect corresponding virtual modules
   stubHostEntry(hostEntryPath);
   stubRemoteEntry(remoteEntryPath);

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -161,6 +161,7 @@ function augmentConfig(
         originalEntryFilename,
         remoteEntryFilename,
         manifestPath,
+        tmpDirPath,
       }),
     },
   };

--- a/packages/core/src/plugin/resolver.ts
+++ b/packages/core/src/plugin/resolver.ts
@@ -196,5 +196,5 @@ function getEntryPathRegex(paths: {
 }): RegExp {
   const relativeEntryPath = path.relative(paths.projectDir, paths.entry);
   const entryName = removeExtension(relativeEntryPath);
-  return new RegExp(`^\\./${entryName}\\.js?$`);
+  return new RegExp(`^\\./${entryName}(\\.js)?$`);
 }

--- a/packages/core/src/plugin/rewrite-request.ts
+++ b/packages/core/src/plugin/rewrite-request.ts
@@ -6,16 +6,24 @@ import { replaceExtension } from './helpers';
 type CreateRewriteRequestOptions = {
   options: ModuleFederationConfigNormalized;
   config: ConfigT;
+  hostEntryPath: string;
   manifestPath: string;
 };
 
 export function createRewriteRequest({
   options,
   config,
+  hostEntryPath,
   manifestPath,
 }: CreateRewriteRequestOptions) {
   return function rewriteRequest(url: string) {
     const { pathname } = new URL(url, 'protocol://host');
+    // rewrite /index.bundle -> /hostEntry.bundle
+    if (pathname.startsWith('/index.bundle')) {
+      const root = config.projectRoot;
+      const target = hostEntryPath.replace(root, '[metro-project]');
+      return url.replace('index.bundle', target);
+    }
     // rewrite /mini.bundle -> /mini.js.bundle
     if (pathname.startsWith(`/${options.filename}`)) {
       const target = replaceExtension(options.filename, '.js.bundle');

--- a/packages/core/src/plugin/rewrite-request.ts
+++ b/packages/core/src/plugin/rewrite-request.ts
@@ -20,7 +20,10 @@ export function createRewriteRequest({
 }: CreateRewriteRequestOptions) {
   const hostEntryName = removeExtension(originalEntryFilename);
   const remoteEntryName = removeExtension(remoteEntryFilename);
-  const relativeTmpDirPath = path.relative(config.projectRoot, tmpDirPath);
+  const relativeTmpDirPath = path
+    .relative(config.projectRoot, tmpDirPath)
+    .split(path.sep)
+    .join(path.posix.sep);
   const hostEntryPathRegex = getEntryPathRegex(hostEntryName);
   const remoteEntryPathRegex = getEntryPathRegex(remoteEntryName);
 

--- a/packages/core/src/runtime/host-entry.js
+++ b/packages/core/src/runtime/host-entry.js
@@ -1,0 +1,8 @@
+// we need to explicitly import the init-host runtime module
+// this is because of a metro limitation, where the module
+// must be used in the bundle in order to be present in the final bundle
+import 'mf:init-host';
+import 'mf:async-require';
+
+// replaced with the actual app entrypoint
+__ENTRYPOINT_IMPORT__;


### PR DESCRIPTION
### Summary

This PR introduces virtual entry for host which allows us to drop the requirement for user to include this piece of code in their `index.js`:

```js
import 'mf:init-host';
import 'mf:async-require';
// ...rest of index.js
```