### PR TITLE
refactor: replace `chalk` with styleText

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -47,8 +47,7 @@
   "dependencies": {
     "@expo/metro-runtime": "^5.0.4",
     "@module-federation/runtime": "^0.15.0",
-    "@module-federation/sdk": "^0.15.0",
-    "chalk": "^5.4.1"
+    "@module-federation/sdk": "^0.15.0"
   },
   "peerDependencies": {
     "@babel/types": "^7.25.0",

--- a/packages/core/src/commands/bundle-host/index.ts
+++ b/packages/core/src/commands/bundle-host/index.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import chalk from 'chalk';
+import util from 'node:util';
 import Server from 'metro/src/Server';
 import type { RequestOptions } from 'metro/src/shared/types';
 import type { ModuleFederationConfigNormalized } from '../../types';
@@ -40,7 +40,7 @@ async function bundleFederatedHost(
   const hostEntryFilepath = global.__METRO_FEDERATION_HOST_ENTRY_PATH;
   if (!hostEntryFilepath) {
     logger.error(
-      `${chalk.red('error')} Cannot determine the host entrypoint path.`
+      `${util.styleText('red', 'error')} Cannot determine the host entrypoint path.`
     );
     throw new CLIError('Bundling failed');
   }

--- a/packages/core/src/commands/bundle-remote/index.ts
+++ b/packages/core/src/commands/bundle-remote/index.ts
@@ -1,7 +1,7 @@
 import { promises as fs } from 'node:fs';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
-import chalk from 'chalk';
+import util from 'node:util';
 import { mergeConfig } from 'metro';
 import Server from 'metro/src/Server';
 import type { OutputOptions, RequestOptions } from 'metro/src/shared/types';
@@ -109,7 +109,7 @@ async function bundleFederatedRemote(
   const federationConfig = global.__METRO_FEDERATION_CONFIG;
   if (!federationConfig) {
     logger.error(
-      `${chalk.red('error')} Module Federation configuration is missing.`
+      `${util.styleText('red', 'error')} Module Federation configuration is missing.`
     );
     logger.info(
       "Import the plugin 'withModuleFederation' " +
@@ -123,7 +123,7 @@ async function bundleFederatedRemote(
   const containerEntryFilepath = global.__METRO_FEDERATION_REMOTE_ENTRY_PATH;
   if (!containerEntryFilepath) {
     logger.error(
-      `${chalk.red('error')} Cannot determine the container entry file path.`
+      `${util.styleText('red', 'error')} Cannot determine the container entry file path.`
     );
     logger.info(
       'To bundle a container, you need to expose at least one module ' +
@@ -136,21 +136,21 @@ async function bundleFederatedRemote(
   const manifestFilepath = global.__METRO_FEDERATION_MANIFEST_PATH;
   if (!manifestFilepath) {
     logger.error(
-      `${chalk.red('error')} Cannot determine the manifest file path.`
+      `${util.styleText('red', 'error')} Cannot determine the manifest file path.`
     );
     throw new CLIError('Bundling failed');
   }
 
   if (rawConfig.resolver.platforms.indexOf(args.platform) === -1) {
     logger.error(
-      `${chalk.red('error')}: Invalid platform ${
-        args.platform ? `"${chalk.bold(args.platform)}" ` : ''
+      `${util.styleText('red', 'error')}: Invalid platform ${
+        args.platform ? `"${util.styleText('bold', args.platform)}" ` : ''
       }selected.`
     );
 
     logger.info(
       `Available platforms are: ${rawConfig.resolver.platforms
-        .map((x) => `"${chalk.bold(x)}"`)
+        .map((x) => `"${util.styleText('bold', x)}"`)
         .join(
           ', '
         )}. If you are trying to bundle for an out-of-tree platform, it may not be installed.`
@@ -316,7 +316,7 @@ async function bundleFederatedRemote(
 
   try {
     logger.info(
-      `${chalk.blue('Processing remote container and exposed modules')}`
+      `${util.styleText('blue', 'Processing remote container and exposed modules')}`
     );
 
     for (const { requestOpts, saveBundleOpts, targetDir } of requests) {
@@ -340,11 +340,11 @@ async function bundleFederatedRemote(
       // );
     }
 
-    logger.info(`${chalk.blue('Processing manifest')}`);
+    logger.info(`${util.styleText('blue', 'Processing manifest')}`);
     const manifestOutputFilepath = path.resolve(outputDir, 'mf-manifest.json');
     await fs.copyFile(manifestFilepath, manifestOutputFilepath);
     logger.info(
-      `Done writing MF Manifest to:\n${chalk.dim(manifestOutputFilepath)}`
+      `Done writing MF Manifest to:\n${util.styleText('dim', manifestOutputFilepath)}`
     );
   } finally {
     // incomplete types - this should be awaited

--- a/packages/core/src/commands/utils/save-bundle-and-map.ts
+++ b/packages/core/src/commands/utils/save-bundle-and-map.ts
@@ -1,5 +1,5 @@
 import { promises as fs } from 'node:fs';
-import chalk from 'chalk';
+import util from 'node:util';
 import type { MixedSourceMap } from 'metro-source-map';
 import relativizeSourceMapInline from 'metro/src/lib/relativizeSourceMap';
 import type { OutputOptions } from 'metro/src/shared/types';
@@ -28,7 +28,7 @@ export async function saveBundleAndMap(
   const writeFns = [];
 
   writeFns.push(async () => {
-    log(`Writing bundle output to:\n${chalk.dim(bundleOutput)}`);
+    log(`Writing bundle output to:\n${util.styleText('dim', bundleOutput)}`);
     await fs.writeFile(bundleOutput, bundle.code, encoding);
     log('Done writing bundle output');
   });
@@ -43,7 +43,9 @@ export async function saveBundleAndMap(
     }
 
     writeFns.push(async () => {
-      log(`Writing sourcemap output to:\n${chalk.dim(sourcemapOutput)}`);
+      log(
+        `Writing sourcemap output to:\n${util.styleText('dim', sourcemapOutput)}`
+      );
       await fs.writeFile(sourcemapOutput, map);
       log('Done writing sourcemap output');
     });

--- a/packages/core/src/plugin/index.ts
+++ b/packages/core/src/plugin/index.ts
@@ -1,5 +1,5 @@
 import path from 'node:path';
-import chalk from 'chalk';
+import util from 'node:util';
 import type { ConfigT } from 'metro-config';
 import type {
   ModuleFederationConfig,
@@ -39,16 +39,18 @@ export function withModuleFederation(
   }
 
   console.warn(
-    chalk.yellow(
+    util.styleText(
+      'yellow',
       'Warning: Module Federation build is disabled for this command.\n'
     ) +
-      chalk.yellow(
+      util.styleText(
+        'yellow',
         'To enable Module Federation, please use one of the dedicated bundle commands:\n'
       ) +
-      ` ${chalk.dim('•')} bundle-mf-host` +
-      chalk.dim(' - for bundling a host application\n') +
-      ` ${chalk.dim('•')} bundle-mf-remote` +
-      chalk.dim(' - for bundling a remote application\n')
+      ` ${util.styleText('dim', '•')} bundle-mf-host` +
+      util.styleText('dim', ' - for bundling a host application\n') +
+      ` ${util.styleText('dim', '•')} bundle-mf-remote` +
+      util.styleText('dim', ' - for bundling a remote application\n')
   );
 
   return config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -477,9 +477,6 @@ importers:
       '@module-federation/sdk':
         specifier: ^0.15.0
         version: 0.15.0
-      chalk:
-        specifier: ^5.4.1
-        version: 5.4.1
     devDependencies:
       '@rslib/core':
         specifier: ^0.10.0


### PR DESCRIPTION
### Summary

removes `chalk` in favour of `util.styleText` from Node (available from `20.12` upwards)